### PR TITLE
Added perform class method for a slightly more stylish interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,18 @@ will prevent the EventMachine event loop from running and block all other reques
 ## Usage
 Inside your Rack app #call(env):
 
-    response = Thin::AsyncResponse.new(env)
-    response.status = 201
-    response.headers["X-Muffin-Mode"] = "ACTIVATED!"
-    
-    response << "this is ... "
-    
-    EM.add_timer(1) do
-      # This will be sent to the client 1 sec later without blocking other requests.
-      response << "async!"
-      response.done
+    Thin::AsyncResponse.perform(env) do |response|
+      response.status = 201
+      response.headers["X-Muffin-Mode"] = "ACTIVATED!"
+
+      response << "this is ... "
+
+      EM.add_timer(1) do
+        # This will be sent to the client 1 sec later without blocking other requests.
+        response << "async!"
+        response.done
+      end
     end
-    
-    response.finish
 
 See example/ dir for more.
 

--- a/lib/thin/async.rb
+++ b/lib/thin/async.rb
@@ -41,6 +41,12 @@ module Thin
     attr_reader :headers, :callback
     attr_accessor :status
 
+    # Creates a instance and yields it to the block given
+    # returns the async marker
+    def self.perform(*args, &block)
+      new(*args, &block).finish
+    end
+
     def initialize(env, status=200, headers={})
       @callback = env['async.callback']
       @body = DeferrableBody.new
@@ -51,7 +57,6 @@ module Thin
 
       if block_given?
         yield self
-        finish
       end
     end
 


### PR DESCRIPTION
In the current code base there is this piece of code in the constructor (https://github.com/macournoyer/thin_async/blob/master/lib/thin/async.rb#L53):

```
      if block_given?
        yield self
        finish
      end
```

The last `finish` doesn't do anything. I assume the idea was to avoid having to explicitly call it at the end of the invoking code, but you can't return anything from a constructor so that won't work as expected. I've now created a class method that wraps the same behaviour, allowing you to write user land code as:

```
Thin::AsyncResponse.perform(env) do |response|
    ...
end
```